### PR TITLE
Fix error on installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name='gym-crawlingrobot', version='1.0.0', install_requires = ['gym==0.21.0','pygame==2.1.2','pymunk==6.2.1', 'matplotlib==3.5.1', 'numpy==1.18.5', 'stable-baselines==2.10.2', 'notebook=6.4.11', 'tensorflow==1.15.0'])
+setup(name='gym-crawlingrobot', version='1.0.0', install_requires = ['gym==0.21.0','pygame==2.1.2','pymunk==6.2.1', 'matplotlib==3.5.1', 'numpy==1.18.5', 'stable-baselines==2.10.2', 'notebook==6.4.11', 'tensorflow==1.15.0'])


### PR DESCRIPTION
A missing '=' in the installation requirements caused the installation to fail